### PR TITLE
Refactoring of two modules

### DIFF
--- a/src/main/java/org/umcn/me/pairedend/AnchorClusterer.java
+++ b/src/main/java/org/umcn/me/pairedend/AnchorClusterer.java
@@ -1,51 +1,20 @@
 package org.umcn.me.pairedend;
 
 import net.sf.samtools.*;
-
+import org.apache.commons.cli.*;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Logger;
-import org.apache.commons.cli.*;
 import org.umcn.me.sam.MateCluster;
 import org.umcn.me.samexternal.IllegalSAMPairException;
 import org.umcn.me.samexternal.SAMSilentReader;
 import org.umcn.me.samexternal.SAMWriting;
 import org.umcn.me.splitread.ClippedRead;
 import org.umcn.me.splitread.InvalidHardClipCigarException;
-import org.umcn.me.tabix.BlacklistAnnotation;
-import org.umcn.me.tabix.RefGeneAnnotation;
-import org.umcn.me.tabix.RepMaskAnnotation;
-import org.umcn.me.tabix.SelfChainAnnotation;
-import org.umcn.me.tabix.TabixBaseAnnotater;
-import org.umcn.me.util.ClippedReadSet;
-import org.umcn.me.util.CollectionUtil;
-import org.umcn.me.util.MobileDefinitions;
-import org.umcn.me.util.ReadName;
-import org.umcn.me.util.ReadNameOption;
-import org.umcn.me.util.ReadNameRetriever;
-import org.umcn.me.util.RegionWithLabel;
-import org.umcn.me.util.SampleBam;
+import org.umcn.me.tabix.*;
+import org.umcn.me.util.*;
 
-import java.io.File;
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.FileWriter;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.HashMap;
+import java.io.*;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -87,7 +56,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class AnchorClusterer {
 	
-	public static Logger logger = Logger.getLogger("AnchorClusterer");
+	public static Logger logger = Logger.getLogger(AnchorClusterer.class.getName());
 	
 	private static final int FILTER_REGION = 90;
 	private static final String VERSION;
@@ -1251,7 +1220,7 @@ public class AnchorClusterer {
 	 * @param predictionFile name of output prediction .txt file
 	 * @throws IOException
 	 */
-	public static Vector<MobilePrediction> clusterMateClusters(File clusterIn, File clusterIndex, int overlap, int maxdist) throws IOException{
+	public static Vector<MobilePrediction> clusterMateClusters(File clusterIn, File clusterIndex, int overlap, int maxdist) {
 		
 		SAMFileReader input = new SAMSilentReader(clusterIn, clusterIndex);
 		SAMFileReader input2 = new SAMSilentReader(clusterIn, clusterIndex);	

--- a/src/main/java/org/umcn/me/pairedend/PotentialMEIReadFinder.java
+++ b/src/main/java/org/umcn/me/pairedend/PotentialMEIReadFinder.java
@@ -1,40 +1,23 @@
 package org.umcn.me.pairedend;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
+import com.google.code.jyield.YieldUtils;
+import net.sf.samtools.SAMFileHeader;
+import net.sf.samtools.SAMFileHeader.SortOrder;
+import net.sf.samtools.SAMFileWriter;
+import org.apache.commons.cli.*;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Logger;
+import org.umcn.me.sam.PotentialMobilePairIterator;
+import org.umcn.me.samexternal.*;
+import org.umcn.me.util.BAMCollection;
+import org.umcn.me.util.BAMSample;
+import org.umcn.me.util.MobileDefinitions;
+
+import java.io.*;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.GnuParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.OptionBuilder;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Logger;
-import org.umcn.me.sam.PotentialMobilePairIterator;
-import org.umcn.me.samexternal.NrMappingsSAMRecordHolder;
-import org.umcn.me.samexternal.SAMDefinitions;
-import org.umcn.me.samexternal.SAMRecordHolderPair;
-import org.umcn.me.samexternal.SAMSilentReader;
-import org.umcn.me.samexternal.SAMWriting;
-import org.umcn.me.util.BAMCollection;
-import org.umcn.me.util.MobileDefinitions;
-import org.umcn.me.util.BAMSample;
-
-import com.google.code.jyield.YieldUtils;
-
-import net.sf.samtools.SAMFileHeader;
-import net.sf.samtools.SAMFileWriter;
-import net.sf.samtools.SAMFileHeader.SortOrder;
 
 public class PotentialMEIReadFinder {
 	
@@ -50,99 +33,34 @@ public class PotentialMEIReadFinder {
 		BasicConfigurator.configure();
 		
 		Options options = addCmdOptions();
-		HelpFormatter formatter = new HelpFormatter();	
-		Properties props = new Properties();
-		
-		String infile;
-		String outfile;
-		String tool;
-		String tmp;
-		Boolean useSplit;
-		int minClipping;
-		int maxClipping;
-		int memory;
-		File propertiesFile;
-		if(args.length == 0){
+
+		if (args.length == 0) {
+			HelpFormatter formatter = new HelpFormatter();
 			formatter.printHelp("java -Xmx4g -jar PotentialMEIFinder.jar", options);
-		}else{
+		} else {
 			CommandLineParser parser = new GnuParser();
 			try {
+
 				long start = System.currentTimeMillis();
-				
 				CommandLine line = parser.parse(options, args);
-				
-				if (line.hasOption("properties")){
-					propertiesFile = new File(line.getOptionValue("properties"));
+
+				if (line.hasOption("properties")) {
+					Properties props = new Properties();
+					File propertiesFile = new File(line.getOptionValue("properties"));
 					props.load(new FileInputStream(propertiesFile));
-					infile = props.getProperty(MobileDefinitions.INFILE).trim();
-					outfile = props.getProperty(MobileDefinitions.OUTFILE).trim();
-					
-					if (props.containsKey(MobileDefinitions.MAPPING_TOOL)){
-						tool = props.getProperty(MobileDefinitions.MAPPING_TOOL).trim();
-					}else{
-						//3-12-2014:Changed from mosaik to unspecified
-						tool = SAMDefinitions.MAPPING_TOOL_UNSPECIFIED;
-					}
-					useSplit = Boolean.parseBoolean(props.getProperty(MobileDefinitions.USE_SPLIT).trim());
-					
-					if (props.containsKey(MobileDefinitions.TMP)){
-						tmp = props.getProperty(MobileDefinitions.TMP).trim();
-					}else{
-						tmp = System.getProperty("java.io.tmpdir");
-					}
-					
-					minClipping = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_CLIPPING).trim());
-					maxClipping = Integer.parseInt(props.getProperty(MobileDefinitions.MAX_CLIPPING).trim());
-					
-					memory = Integer.parseInt(props.getProperty(MobileDefinitions.MEMORY).trim());
-					
-					min_avg_qual = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_QUAL).trim());
-					if (props.containsKey(MobileDefinitions.MIN_MAPQ_ANCHOR)){
-						min_anchor_mapq = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_MAPQ_ANCHOR).trim());
-					}
-					if (props.containsKey(MobileDefinitions.GRIPS_DISCARD_UNIQUE_MULTIPLE)){
-						skip_um_pairs = Boolean.parseBoolean(props.getProperty(MobileDefinitions.GRIPS_DISCARD_UNIQUE_MULTIPLE).trim());
-					}
-					
-				}else{
-					infile = line.getOptionValue("in");
-					outfile = line.getOptionValue("out");
-					tool = line.getOptionValue("tool", SAMDefinitions.MAPPING_TOOL_UNSPECIFIED); //3-12-2014:Changed from mosaik to unspecified
-					useSplit = line.hasOption("split");
-					tmp = line.getOptionValue("tmp", System.getProperty("java.io.tmpdir"));
-					minClipping = Integer.parseInt(line.getOptionValue("minclip", "35")); //30-1-2015: typo in option parsing min --> minclip
-					maxClipping = Integer.parseInt(line.getOptionValue("maxclip", "7")); //30-1-2015: typo in option parsing max --> maxclip
-					memory = Integer.parseInt(line.getOptionValue("max_memory", Integer.toString(SAMWriting.MAX_RECORDS_IN_RAM)));
-					min_avg_qual = Integer.parseInt(line.getOptionValue("min_avg_qual", Integer.toString(min_avg_qual)));
-					min_anchor_mapq = Integer.parseInt(line.getOptionValue("mapq",Integer.toString(min_anchor_mapq)));
-					
-					//TODO: add in skip um pair as an cli option
+					ValuesParsedFromPropertiesOrCmdLine valuesParsedFromPropertiesFile = new ValuesParsedFromPropertiesOrCmdLine(props);
+					valuesParsedFromPropertiesFile.log();
+				} else {
+					ValuesParsedFromPropertiesOrCmdLine valuesParsedFromCmdLine = new ValuesParsedFromPropertiesOrCmdLine(line);
+					valuesParsedFromCmdLine.log();
 				}
 				
-				logger.info("Using infile: " + infile);
-				logger.info("Using out prefix: " + outfile);
-				logger.info("Used mapping tool: " + tool);
-				logger.info("Including split reads: " + useSplit);
-				logger.info("Maximum records in memory: " + memory);
-				logger.info("Temp directory: " + tmp);
-				logger.info("Split reads should have min avg qual of: " + min_avg_qual);
-				
-				if(useSplit){
-					logger.info("Minimum clipping of: " + minClipping);
-					logger.info("Maximum clipping of other side: " + maxClipping);
-				}
-				
-				if (tool.equals(SAMDefinitions.MAPPING_TOOL_UNSPECIFIED)){
-					logger.info("Using mapq of: " + min_anchor_mapq +  "for defining anchors");
-				}
-				
-				//TODO1: Open up the .fq and .bam writer here, then run the potential MEIFinder
+				//TODO: Open up the .fq and .bam writer here, then run the potential MEIFinder
 				
 				//Loop over runPotentialMEIFinder depending on the number of BAM files given
 				//runPotentialMEIFinder(infile, outfile, tool, tmp, useSplit, minClipping, maxClipping, memory); 
-				
-				
-				//TODO3: Close the .fq and .bam writer here.
+
+				//TODO: Close the .fq and .bam writer here.
 				
 				long end = System.currentTimeMillis();
 				long millis = end - start;
@@ -163,14 +81,85 @@ public class PotentialMEIReadFinder {
 				logger.error(e.getMessage());
 			}
 		}
-		   
 	}
-	
-	//TODO remove duplicate code for this function
-	public static void runFromProperties(Properties props) throws IOException {
-		
-		//TODO
-//		String infile;
+
+	private static Options addCmdOptions() {
+		Options options = new Options();
+
+		OptionBuilder.withArgName("BAM File");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("BAM file containing mapped and unmapped paired-end reads" +
+				" against human reference genome");
+
+		options.addOption(OptionBuilder.create("in"));
+
+		OptionBuilder.withArgName("prefix");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Output prefix for BAM files and fq files" +
+				" containing supporting potential MEI paired-end reads");
+
+		options.addOption(OptionBuilder.create("out"));
+
+		OptionBuilder.withArgName("Tool Name");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Tool used for read mapping against reference");
+
+		options.addOption(OptionBuilder.create("tool"));
+
+		OptionBuilder.withDescription("use this option (-split) if you want to include split reads");
+
+		options.addOption(OptionBuilder.create("split"));
+
+		OptionBuilder.withArgName("int");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Minimum size of clipped sequence for a split-read. Only used " +
+				"when -split is supplied.");
+
+		options.addOption(OptionBuilder.create("minclip"));
+
+		OptionBuilder.withArgName("int");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Maximum size of clipping for the end opposite of the end which has a " +
+				"minimum clipping of at least the number specified by -minclip. Only used " +
+				"when -split is supplied.");
+
+		options.addOption(OptionBuilder.create("maxclip"));
+
+		OptionBuilder.withArgName("int");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Minimum average base quality for clipped read. Default = " + min_avg_qual);
+
+		options.addOption(OptionBuilder.create("min_avg_qual"));
+
+		OptionBuilder.withArgName("dir");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Tmp directory to use, when writing large files");
+
+		options.addOption(OptionBuilder.create("tmp"));
+
+		OptionBuilder.withArgName("int");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Alter the number of records in memory (increase to decrease number of file handles). Default: " + SAMWriting.MAX_RECORDS_IN_RAM);
+
+		options.addOption(OptionBuilder.create("max_memory"));
+
+		OptionBuilder.withArgName("string");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Use property file instead of command line arguments, command line arguments will be skipt. Values in property file will be used");
+
+		options.addOption(OptionBuilder.create("properties"));
+
+		OptionBuilder.withArgName("int");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Minimum mapq needed for anchors. ONLY USED when -tool is unspecified. Default: " + min_anchor_mapq );
+
+		options.addOption(OptionBuilder.create("mapq"));
+
+		return options;
+	}
+
+	private static final class ValuesParsedFromPropertiesOrCmdLine {
+		String infile;
 		String outfile;
 		String tool;
 		File tmp;
@@ -178,157 +167,164 @@ public class PotentialMEIReadFinder {
 		int minClipping;
 		int maxClipping;
 		int memory;
-		
-		String[] samples;
-		String[] bams;
-		
+
+		ValuesParsedFromPropertiesOrCmdLine (Properties props) throws IOException{
+			infile = props.getProperty(MobileDefinitions.INFILE).trim();
+
+			outfile = props.getProperty(MobileDefinitions.OUTFILE).trim();
+
+			if (props.containsKey(MobileDefinitions.MAPPING_TOOL)) {
+				tool = props.getProperty(MobileDefinitions.MAPPING_TOOL).trim();
+			} else {
+				//3-12-2014:Changed from mosaik to unspecified
+				tool = SAMDefinitions.MAPPING_TOOL_UNSPECIFIED;
+			}
+
+			useSplit = Boolean.parseBoolean(props.getProperty(MobileDefinitions.USE_SPLIT).trim());
+
+			if (props.containsKey(MobileDefinitions.TMP)) {
+				tmp = new File(props.getProperty(MobileDefinitions.TMP).trim() + File.separator + "mob_" + Long.toString(System.nanoTime()));
+			} else {
+				tmp = new File(System.getProperty("java.io.tmpdir") + File.separator + "mob_" + Long.toString(System.nanoTime()));
+			}
+			if ( ! tmp.mkdir() ) {
+				throw new IOException("Can not create tmp directory: " + tmp);
+			}
+
+			minClipping = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_CLIPPING).trim());
+			maxClipping = Integer.parseInt(props.getProperty(MobileDefinitions.MAX_CLIPPING).trim());
+
+			memory = Integer.parseInt(props.getProperty(MobileDefinitions.MEMORY).trim());
+
+			min_avg_qual = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_QUAL).trim());
+
+			if (props.containsKey(MobileDefinitions.GRIPS_DISCARD_UNIQUE_MULTIPLE)) {
+				skip_um_pairs = Boolean.parseBoolean(props.getProperty(MobileDefinitions.GRIPS_DISCARD_UNIQUE_MULTIPLE).trim());
+			}
+
+			if (tool.equals(SAMDefinitions.MAPPING_TOOL_UNSPECIFIED)
+					&&
+					props.containsKey(MobileDefinitions.MIN_MAPQ_ANCHOR)) {
+				min_anchor_mapq = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_MAPQ_ANCHOR));
+			}
+		}
+
+		ValuesParsedFromPropertiesOrCmdLine (CommandLine line) {
+			infile = line.getOptionValue("in");
+			outfile = line.getOptionValue("out");
+			tool = line.getOptionValue("tool", SAMDefinitions.MAPPING_TOOL_UNSPECIFIED); //3-12-2014:Changed from mosaik to unspecified
+			useSplit = line.hasOption("split");
+			tmp = new File( line.getOptionValue("tmp", System.getProperty("java.io.tmpdir")) );
+			minClipping = Integer.parseInt(line.getOptionValue("minclip", "35")); //30-1-2015: typo in option parsing min --> minclip
+			maxClipping = Integer.parseInt(line.getOptionValue("maxclip", "7")); //30-1-2015: typo in option parsing max --> maxclip
+			memory = Integer.parseInt(line.getOptionValue("max_memory", Integer.toString(SAMWriting.MAX_RECORDS_IN_RAM)));
+			min_avg_qual = Integer.parseInt(line.getOptionValue("min_avg_qual", Integer.toString(min_avg_qual)));
+			min_anchor_mapq = Integer.parseInt(line.getOptionValue("mapq",Integer.toString(min_anchor_mapq)));
+
+			//TODO: add in skip um pair as an cli option
+		}
+
+		void log() {
+			logger.info("Using infile(s): " + infile);
+			logger.info("Using out prefix: " + outfile);
+			logger.info("Used mapping tool: " + tool);
+			logger.info("Including split reads: " + useSplit);
+			logger.info("Maximum records in memory: " + memory);
+			logger.info("Temp directory: " + tmp);
+			logger.info("Split reads should have min avg qual of: " + min_avg_qual);
+
+			if(useSplit){
+				logger.info("Minimum clipping of: " + minClipping);
+				logger.info("Maximum clipping of other side: " + maxClipping);
+			}
+
+			if (tool.equals(SAMDefinitions.MAPPING_TOOL_UNSPECIFIED)){
+				logger.info("Using mapq of: " + min_anchor_mapq +  "for defining anchors");
+			}
+		}
+	}
+
+	// =================================================================================================================
+
+	//TODO remove duplicate code for this function
+	public static void runFromProperties(Properties props) throws IOException {
+
 		long start = System.currentTimeMillis();
-		
-		//TODO
-		//infile = props.getProperty(MobileDefinitions.INFILE).trim();
-		outfile = props.getProperty(MobileDefinitions.OUTFILE).trim();
-		
-		if (props.containsKey(MobileDefinitions.MAPPING_TOOL)){
-			tool = props.getProperty(MobileDefinitions.MAPPING_TOOL).trim();
-		}else{
-			//3-12-2014:Changed from mosaik to unspecified
-			tool = SAMDefinitions.MAPPING_TOOL_UNSPECIFIED;
-		}
-		
-		if (props.containsKey(MobileDefinitions.GRIPS_DISCARD_UNIQUE_MULTIPLE)){
-			skip_um_pairs = Boolean.parseBoolean(props.getProperty(MobileDefinitions.GRIPS_DISCARD_UNIQUE_MULTIPLE).trim());
-		}
-		
-		if (props.containsKey(MobileDefinitions.QUERY_SORT_INPUT)){
+		ValuesParsedFromPropertiesOrCmdLine valuesParsedFromPropertiesFile = new ValuesParsedFromPropertiesOrCmdLine(props);
+		valuesParsedFromPropertiesFile.log();
+
+		if (props.containsKey(MobileDefinitions.QUERY_SORT_INPUT)) {
 			query_sort_input = Boolean.parseBoolean(props.getProperty(MobileDefinitions.QUERY_SORT_INPUT).trim());
 		}
-		
-		useSplit = Boolean.parseBoolean(props.getProperty(MobileDefinitions.USE_SPLIT).trim());
-		
-		if (props.containsKey(MobileDefinitions.TMP)){
-			tmp = new File(props.getProperty(MobileDefinitions.TMP).trim() + File.separator + "mob_" + Long.toString(System.nanoTime()));			
-		}else{
-			tmp = new File(System.getProperty("java.io.tmpdir") + File.separator + "mob_" + Long.toString(System.nanoTime()));
-		}
-		
-		
-		if ( ! tmp.mkdir() ){
-			throw new IOException("Can not create tmp directory: " + tmp);
-		}
+
+		//TODO: If multiple samples were found, turn on the multiple_sample_calling option in the properties from Mobster.java
+
 		//TODO: Sample parsing
-		samples = props.getProperty(MobileDefinitions.SAMPLE_NAME).split(MobileDefinitions.DEFAULT_SEP, 0);
-		bams = props.getProperty(MobileDefinitions.INFILE).split(MobileDefinitions.DEFAULT_SEP, 0);
-		
+		String[] samples = props.getProperty(MobileDefinitions.SAMPLE_NAME).split(MobileDefinitions.DEFAULT_SEP, 0);
+		String[] bams = props.getProperty(MobileDefinitions.INFILE).split(MobileDefinitions.DEFAULT_SEP, 0);
+
 		//Check to see whether bam names are unique
-		if (bams.length != new HashSet<String>(Arrays.asList(bams)).size()){
+		if (bams.length != new HashSet<String>(Arrays.asList(bams)).size()) {
 			logger.error("Supplied bams are not unique");
 			System.exit(1);
 		}
-		
-		if (bams.length != samples.length){
+
+		if (bams.length != samples.length) {
 			logger.error("Number of sample names do not match number of supplied bams");
 			System.exit(1);
 		}
 
-		//TODO: If multiple samples were found, turn on the multiple_sample_calling option in the properties from Mobster.java
-		
-		minClipping = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_CLIPPING).trim());
-		maxClipping = Integer.parseInt(props.getProperty(MobileDefinitions.MAX_CLIPPING).trim());
-		
-		memory = Integer.parseInt(props.getProperty(MobileDefinitions.MEMORY).trim());
-		
-		min_avg_qual = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_QUAL).trim());
-		
-		logger.info("Using infile(s): " + props.getProperty(MobileDefinitions.INFILE));
-		logger.info("Using out prefix: " + outfile);
-		logger.info("Used mapping tool: " + tool);
-		logger.info("Including split reads: " + useSplit);
-		logger.info("Maximum records in memory: " + memory);
-		logger.info("Temp directory: " + tmp);
-		logger.info("Split reads should have min avg qual of: " + min_avg_qual);
 		logger.info("Number of samples detected: " + samples.length);
-		
-		if(useSplit){
-			logger.info("Minimum clipping of: " + minClipping);
-			logger.info("Maximum clipping of other side: " + maxClipping);
-		}
-		
-		if (tool.equals(SAMDefinitions.MAPPING_TOOL_UNSPECIFIED)){
-			min_anchor_mapq = Integer.parseInt(props.getProperty(MobileDefinitions.MIN_MAPQ_ANCHOR));
-			logger.info("Using mapq of: " + min_anchor_mapq +  "for defining anchors");
-		}
-		
-		
+
 		PrintWriter outFq = null;
 		SAMFileWriter outputSam = null;
 		SAMFileHeader samFileHeader = null;
-		File nameSortedBam = null;
 		try {
 			
-			outFq = new PrintWriter(new FileWriter(outfile + "_potential.fq"), true);
+			outFq = new PrintWriter(new FileWriter(valuesParsedFromPropertiesFile.outfile + "_potential.fq"), true);
 			
 			//If more than one bam then try to make unique RG ids and associate sample name to each bam
-			if (bams.length > 1){
+			if (bams.length > 1) {
 				logger.info("[PMRF] detected multiple samples, modifying RG's");
 				BAMCollection collection = new BAMCollection(bams, samples, true);
 				
 				samFileHeader = collection.getMergedHeader(SAMFileHeader.SortOrder.unsorted);
-				
-				outputSam = SAMWriting.makeSAMWriter(new File(outfile + "_potential.bam"), samFileHeader, tmp, memory, SAMFileHeader.SortOrder.unsorted, true);
+				outputSam = SAMWriting.makeSAMWriter(new File(valuesParsedFromPropertiesFile.outfile + "_potential.bam"),
+						samFileHeader, valuesParsedFromPropertiesFile.tmp, valuesParsedFromPropertiesFile.memory,
+						SAMFileHeader.SortOrder.unsorted, true);
 				
 				//TODO: Loop over runPotentialMEIFinder depending on the number of BAM files given
 				for (BAMSample bamSample : collection.getCloneOfBAMSampleList()){
-				
-					//Query sort input if user wants this
-					if (query_sort_input){
-						nameSortedBam = new File(bamSample.getBam().toString() + ".query_sorted");
-						SAMWriting.writeSortedSAMorBAM(bamSample.getBam(), nameSortedBam, tmp, memory, SortOrder.queryname);
-						runPotentialMEIFinder(nameSortedBam.getAbsolutePath().toString(), outFq, outputSam, tool, useSplit, minClipping, maxClipping, collection.getPrefixReadGroupIdFromBam(bamSample));
-						nameSortedBam.delete();
-					}else{
-						runPotentialMEIFinder(bamSample.getBam().getAbsolutePath(), outFq, outputSam, tool, useSplit, minClipping, maxClipping, collection.getPrefixReadGroupIdFromBam(bamSample));
-					}
-					
+					worker(bamSample.getBam(), valuesParsedFromPropertiesFile, outputSam, outFq,
+							collection.getPrefixReadGroupIdFromBam(bamSample));
 				}
-			//Otherwise if there is just 1 bam, do not try to modify the read groups. 
-			}else if(bams.length == 1){
+			// Otherwise if there is just 1 bam, do not try to modify the read groups.
+			} else if (bams.length == 1) {
 				logger.info("[PMRF] detected one sample, not modifying RG's");
 				SAMSilentReader reader = new SAMSilentReader(new File(bams[0]));
 				samFileHeader = reader.getFileHeader();
-				outputSam = SAMWriting.makeSAMWriter(new File(outfile + "_potential.bam"), samFileHeader, tmp, memory, SAMFileHeader.SortOrder.unsorted, true);
+				outputSam = SAMWriting.makeSAMWriter(new File(valuesParsedFromPropertiesFile.outfile + "_potential.bam"),
+						samFileHeader, valuesParsedFromPropertiesFile.tmp, valuesParsedFromPropertiesFile.memory,
+						SAMFileHeader.SortOrder.unsorted, true);
 				reader.close();
-				
-				if (query_sort_input){
-					nameSortedBam = new File(bams[0] + ".query_sorted");
-					SAMWriting.writeSortedSAMorBAM(new File(bams[0]), nameSortedBam, tmp, memory, SortOrder.queryname);
-					runPotentialMEIFinder(nameSortedBam.getAbsolutePath().toString(), outFq, outputSam, tool, useSplit, minClipping, maxClipping, "");
-					nameSortedBam.delete();
-				}else{
-					runPotentialMEIFinder(bams[0], outFq, outputSam, tool, useSplit, minClipping, maxClipping, "");
-				}
-			}
-			
-			
 
-		} catch (IllegalArgumentException e){
+				File bamSample = new File(bams[0]);
+				worker(bamSample, valuesParsedFromPropertiesFile, outputSam, outFq, "");
+			}
+		} catch (IllegalArgumentException e) {
 			logger.fatal(e.getMessage());
-		}
-		
-		catch (IOException e) {
+		} catch (IOException e) {
 			logger.error("[PMRF] Could not create or find file / directory");
 			logger.error(e.getMessage());
 		} finally {
-			if (outFq != null){
+			if (outFq != null) {
 				outFq.close();
 			}
-			if (outputSam != null){
+			if (outputSam != null) {
 				outputSam.close();
 			}
-			if (nameSortedBam != null){
-				nameSortedBam.delete();
-			}
-			if (tmp != null && ! tmp.delete() ){
-				logger.error("[PMRF] Could not delete temp: " + tmp);
+			if (valuesParsedFromPropertiesFile.tmp != null && ! valuesParsedFromPropertiesFile.tmp.delete() ) {
+				logger.error("[PMRF] Could not delete temp: " + valuesParsedFromPropertiesFile.tmp);
 			}
 		}
 		
@@ -336,15 +332,31 @@ public class PotentialMEIReadFinder {
 		long millis = end - start;
 		String time = String.format("%d min, %d sec", 
 			    TimeUnit.MILLISECONDS.toMinutes(millis),
-			    TimeUnit.MILLISECONDS.toSeconds(millis) - 
+			    TimeUnit.MILLISECONDS.toSeconds(millis) -
 			    TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(millis))
 			);
 		
 		logger.info("[PMRF] PotentialMEIReadFinder ran in : " + time);
-		
 	}
 
-	public static void runPotentialMEIFinder(String inFile, PrintWriter outFq, SAMFileWriter outSam, String mappingTool,
+	private static void worker(File bamSample, ValuesParsedFromPropertiesOrCmdLine values,
+							   SAMFileWriter outputSam, PrintWriter outFq, String prefix) throws FileNotFoundException {
+		//Query sort input if user wants this
+		if (query_sort_input){
+			File nameSortedBam = new File(bamSample.toString() + ".query_sorted");
+			SAMWriting.writeSortedSAMorBAM(bamSample, nameSortedBam, values.tmp, values.memory, SortOrder.queryname);
+
+			runPotentialMEIFinder(nameSortedBam.getAbsolutePath(), outFq, outputSam,
+					values.tool, values.useSplit, values.minClipping, values.maxClipping, prefix);
+
+			nameSortedBam.delete();
+		}else{
+			runPotentialMEIFinder(bamSample.getAbsolutePath(), outFq, outputSam,
+					values.tool, values.useSplit, values.minClipping, values.maxClipping, prefix);
+		}
+	}
+
+	private static void runPotentialMEIFinder(String inFile, PrintWriter outFq, SAMFileWriter outSam, String mappingTool,
 			boolean useSplit, int minClipping, int maxClipping, String readGroupPrefix) {
 		
 		File inBam = new File(inFile);
@@ -380,81 +392,5 @@ public class PotentialMEIReadFinder {
 		//outputSam.close();
 		logger.info("Found nr of potential mobile pairs supporting MEI events: " + c);
 		logger.info("Of which " + d + " are of split-read nature.");
-	}
-	
-	private static Options addCmdOptions() {
-		Options options = new Options();
-		
-		OptionBuilder.withArgName("BAM File");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("BAM file containing mapped and unmapped paired-end reads" +
-				" against human reference genome");
-		
-		options.addOption(OptionBuilder.create("in"));
-		
-		OptionBuilder.withArgName("prefix");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Output prefix for BAM files and fq files" +
-				" containing supporting potential MEI paired-end reads");
-		
-		options.addOption(OptionBuilder.create("out"));
-		
-		OptionBuilder.withArgName("Tool Name");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Tool used for read mapping against reference");
-		
-		options.addOption(OptionBuilder.create("tool"));
-		
-		OptionBuilder.withDescription("use this option (-split) if you want to include split reads");
-		
-		options.addOption(OptionBuilder.create("split"));
-		
-		OptionBuilder.withArgName("int");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Minimum size of clipped sequence for a split-read. Only used " +
-				"when -split is supplied.");
-		
-		options.addOption(OptionBuilder.create("minclip"));
-		
-		OptionBuilder.withArgName("int");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Maximum size of clipping for the end opposite of the end which has a " +
-				"minimum clipping of at least the number specified by -minclip. Only used " +
-				"when -split is supplied.");
-		
-		options.addOption(OptionBuilder.create("maxclip"));
-		
-		OptionBuilder.withArgName("int");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Minimum average base quality for clipped read. Default = " + min_avg_qual);
-		
-		options.addOption(OptionBuilder.create("min_avg_qual"));
-		
-		OptionBuilder.withArgName("dir");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Tmp directory to use, when writing large files");
-		
-		options.addOption(OptionBuilder.create("tmp"));
-		
-		OptionBuilder.withArgName("int");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Alter the number of records in memory (increase to decrease number of file handles). Default: " + SAMWriting.MAX_RECORDS_IN_RAM);
-		
-		options.addOption(OptionBuilder.create("max_memory"));
-		
-		OptionBuilder.withArgName("string");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Use property file instead of command line arguments, command line arguments will be skipt. Values in property file will be used");
-		
-		options.addOption(OptionBuilder.create("properties"));
-		
-		OptionBuilder.withArgName("int");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Minimum mapq needed for anchors. ONLY USED when -tool is unspecified. Default: " + min_anchor_mapq );
-		
-		options.addOption(OptionBuilder.create("mapq"));
-		
-		return options;
-		
 	}
 }

--- a/src/main/java/org/umcn/me/pairedend/RefAndMEPairFinder.java
+++ b/src/main/java/org/umcn/me/pairedend/RefAndMEPairFinder.java
@@ -57,7 +57,7 @@ import org.umcn.me.util.NucleotideSequence;
  */
 public class RefAndMEPairFinder {
 
-	public static Logger logger = Logger.getLogger("RefAndMEPairFinder"); 
+	public static Logger logger = Logger.getLogger(RefAndMEPairFinder.class.getName());
 	private static int MIN_POLYA_LEN = 9;
 	private static int MAX_POLYA_MM = 1;
 	private static int MAX_MAPPINGS = -1; // -1 do not use max mobiome mappings
@@ -67,79 +67,31 @@ public class RefAndMEPairFinder {
 	
 	public static void main(String[] args) {
 		Options options;
-		File single = null;
-		File multiple = null;
-		File filtered = null;
-		String out;
-		String sampleName = "";
-		String tool = "";
-		Boolean paired;
-		Properties prop = new Properties();
-		
-		
-		HelpFormatter formatter = new HelpFormatter();
 		BasicConfigurator.configure();
-		
 		options = createCmdOptions();
-		
+
 		if(args.length == 0){
+			HelpFormatter formatter = new HelpFormatter();
 			formatter.printHelp("java -Xmx4g -jar RefAndMEPairFinder.jar" , options);
-		}else{
+		} else {
 			CommandLineParser parser = new GnuParser();
 			try {
 				long start = System.currentTimeMillis();
-				
 				CommandLine line = parser.parse(options, args);
-				
-				if(line.hasOption("properties")){
+
+				ValuesParsedFromPropertiesOrCmdLine valuesParsed;
+				if (line.hasOption("properties")) {
+					Properties prop = new Properties();
 					prop.load(new FileInputStream(new File(line.getOptionValue("properties"))));
-					single = new File(prop.getProperty(MobileDefinitions.INFILE_FROM_MOBIOME_MAPPING).trim());
-					//we are skipping the multiple input
-					
-					filtered = new File(prop.getProperty(MobileDefinitions.INFILE_FROM_POTENTIAL_MEI_FINDER).trim());
-					out = prop.getProperty(MobileDefinitions.OUTFILE).trim();
-					sampleName = prop.getProperty(MobileDefinitions.SAMPLE_NAME);
-					tool = prop.getProperty(MobileDefinitions.MOBIOME_MAPPING_TOOL);
-					paired = Boolean.parseBoolean(prop.getProperty(MobileDefinitions.PAIRED_END).trim());
-					MIN_POLYA_LEN = Integer.parseInt(prop.getProperty(MobileDefinitions.POLY_A_LENGTH).trim());
-					MAX_POLYA_MM = Integer.parseInt(prop.getProperty(MobileDefinitions.POLY_A_MAX_MISMATCHES).trim());
-					
-					if (prop.containsKey(MobileDefinitions.TMP)){
-						TMP = prop.getProperty(MobileDefinitions.TMP).trim();
-					}else{
-						TMP = System.getProperty("java.io.tmpdir");
-					}
-					if (prop.containsKey(MobileDefinitions.GRIPS_MAX_REFSEQ_MAPPING)){
-						MAX_MAPPINGS = Integer.parseInt(prop.getProperty(MobileDefinitions.GRIPS_MAX_REFSEQ_MAPPING));
-					}
-					
-					MEMORY = Integer.parseInt(prop.getProperty(MobileDefinitions.MEMORY).trim());
-					
-					
-				}else{
-					single = new File(line.getOptionValue("single"));
-					if(line.hasOption("multiple")){
-						multiple = new File(line.getOptionValue("multiple"));
-						logger.info("Checking for reads mapping to multiple superfamilies");
-					}else{
-						logger.info("Not checking for reads mapping to multiple superfamilies");
-					}
-					filtered = new File(line.getOptionValue("potential"));
-					out = line.getOptionValue("out");
-					tool = line.getOptionValue("tool", SAMDefinitions.MAPPING_TOOL_MOSAIK);
-					sampleName = line.getOptionValue("samplename", sampleName);
-					paired = line.hasOption("p");
-					MAX_MAPPINGS = Integer.parseInt(line.getOptionValue("max_mapping", Integer.toString(MAX_MAPPINGS)));
-					TMP = line.getOptionValue("tmp", System.getProperty("java.io.tmpdir"));
-					MEMORY = Integer.parseInt(line.getOptionValue("max_memory", Integer.toString(SAMWriting.MAX_RECORDS_IN_RAM)));
+					valuesParsed = new ValuesParsedFromPropertiesOrCmdLine(prop);
+				} else {
+					valuesParsed = new ValuesParsedFromPropertiesOrCmdLine(line);
 				}
-				logger.info("Using potential .bam file: " + filtered);
-				logger.info("Using output prefix: " + out);
-				logger.info("Mapping tool used for mobile mapping: " + tool);
-				logger.info("Paired-end reads: " + paired);
-				logger.info("Setting sample name to: " + sampleName);
-				
-				runRefAndMePairFinder(single, multiple, filtered, out, tool, paired, sampleName);
+
+				valuesParsed.log();
+
+				runRefAndMePairFinder(valuesParsed.single, valuesParsed.multiple, valuesParsed.filtered, valuesParsed.out,
+						valuesParsed.tool, valuesParsed.paired, valuesParsed.sampleName);
 				
 				long end = System.currentTimeMillis();
 				long millis = end - start;
@@ -157,12 +109,83 @@ public class RefAndMEPairFinder {
 				logger.error("Error in finding files: " + ex.getMessage());
 			}
 		}
- 
 	}
-	
-	//TODO remove the duplicated code associated with this code
-	public static void runFromPropertiesFile(Properties prop) throws IOException{
-		
+
+	private static Options createCmdOptions() {
+		Options options = new Options();
+
+		OptionBuilder.withArgName("BAM File");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("BAM file (NAME-sorted!) from mobile ref mapping," +
+				"containing at most 1 mapping per read");
+
+		options.addOption(OptionBuilder.create("single"));
+
+		OptionBuilder.withArgName("BAM File");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("BAM file (NAME-sorted!) from mobile ref mapping,"
+				+ "containing all mappings of multiply mapped reads");
+
+		options.addOption(OptionBuilder.create("multiple"));
+
+		OptionBuilder.withArgName("BAM File");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("BAM file containing pairs potentially supporting MEI events" +
+				" (output BAM file of PotentialMEIFinder");
+
+		options.addOption(OptionBuilder.create("potential"));
+
+		OptionBuilder.withArgName("prefix");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Output prefix for BAM file containing anchors");
+
+		options.addOption(OptionBuilder.create("out"));
+
+		OptionBuilder.withArgName("Mapping tool");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Mapping tool used for mobile mapping, default: " +
+				SAMDefinitions.MAPPING_TOOL_MOSAIK);
+
+		options.addOption(OptionBuilder.create("tool"));
+
+		OptionBuilder.withArgName("Paired-End Data");
+		OptionBuilder.withDescription("Whether the original mapping is done using paired-end reads." +
+				" Leave -p out when using single-end fragment data.");
+
+		options.addOption(OptionBuilder.create("p"));
+
+		OptionBuilder.withArgName("SampleName");
+		OptionBuilder.withDescription("name of sample");
+		options.addOption(OptionBuilder.create("samplename"));
+
+		OptionBuilder.withArgName("dir");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Tmp directory to use, when writing large files");
+
+		options.addOption(OptionBuilder.create("tmp"));
+
+		OptionBuilder.withArgName("int");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Alter the number of records in memory (increase to decrease number of file handles). Default: " + SAMWriting.MAX_RECORDS_IN_RAM);
+
+		options.addOption(OptionBuilder.create("max_memory"));
+
+		OptionBuilder.withArgName("string");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Use property file instead of command line arguments, command line arguments will be skipt. Values in property file will be used");
+
+		options.addOption(OptionBuilder.create("properties"));
+
+		OptionBuilder.withArgName("int");
+		OptionBuilder.hasArg();
+		OptionBuilder.withDescription("Maximum number of mappings a read may map to the mobiome");
+		options.addOption(OptionBuilder.create("max_mapping"));
+
+		return options;
+	}
+
+	private static final class ValuesParsedFromPropertiesOrCmdLine {
+
 		File single = null;
 		File multiple = null;
 		File filtered = null;
@@ -170,73 +193,109 @@ public class RefAndMEPairFinder {
 		String sampleName = "";
 		String tool = "";
 		Boolean paired;
-		
+		File tmp;
+
+		ValuesParsedFromPropertiesOrCmdLine (Properties props) throws IOException {
+			single = new File(props.getProperty(MobileDefinitions.INFILE_FROM_MOBIOME_MAPPING).trim());
+			//we are skipping the multiple input
+
+			filtered = new File(props.getProperty(MobileDefinitions.INFILE_FROM_POTENTIAL_MEI_FINDER).trim());
+			out = props.getProperty(MobileDefinitions.OUTFILE).trim();
+			sampleName = props.getProperty(MobileDefinitions.SAMPLE_NAME);
+			tool = props.getProperty(MobileDefinitions.MOBIOME_MAPPING_TOOL);
+			paired = Boolean.parseBoolean(props.getProperty(MobileDefinitions.PAIRED_END).trim());
+			MIN_POLYA_LEN = Integer.parseInt(props.getProperty(MobileDefinitions.POLY_A_LENGTH).trim());
+			MAX_POLYA_MM = Integer.parseInt(props.getProperty(MobileDefinitions.POLY_A_MAX_MISMATCHES).trim());
+
+			if (props.containsKey(MobileDefinitions.GRIPS_MAX_REFSEQ_MAPPING)) {
+				MAX_MAPPINGS = Integer.parseInt(props.getProperty(MobileDefinitions.GRIPS_MAX_REFSEQ_MAPPING));
+			}
+
+			if (props.containsKey(MobileDefinitions.TMP)) {
+				TMP = props.getProperty(MobileDefinitions.TMP).trim() + File.separator + "mob_" + Long.toString(System.nanoTime());
+			} else {
+				TMP = System.getProperty("java.io.tmpdir") + File.separator + "mob_" + Long.toString(System.nanoTime());
+			}
+
+			tmp = new File(TMP);
+
+			if ( ! tmp.mkdir() ) {
+				throw new IOException("Can not create tmp directory: " + tmp);
+			}
+			MEMORY = Integer.parseInt(props.getProperty(MobileDefinitions.MEMORY).trim());
+		}
+
+		ValuesParsedFromPropertiesOrCmdLine (CommandLine line) throws IOException {
+			single = new File(line.getOptionValue("single"));
+			if(line.hasOption("multiple")){
+				multiple = new File(line.getOptionValue("multiple"));
+				logger.info("Checking for reads mapping to multiple superfamilies");
+			} else {
+				logger.info("Not checking for reads mapping to multiple superfamilies");
+			}
+			filtered = new File(line.getOptionValue("potential"));
+			out = line.getOptionValue("out");
+			tool = line.getOptionValue("tool", SAMDefinitions.MAPPING_TOOL_MOSAIK);
+			sampleName = line.getOptionValue("samplename", sampleName);
+			paired = line.hasOption("p");
+			MAX_MAPPINGS = Integer.parseInt(line.getOptionValue("max_mapping", Integer.toString(MAX_MAPPINGS)));
+			TMP = line.getOptionValue("tmp", System.getProperty("java.io.tmpdir"));
+			tmp = new File(TMP);
+			if ( ! tmp.mkdir() ) {
+				throw new IOException("Can not create tmp directory: " + tmp);
+			}
+			MEMORY = Integer.parseInt(line.getOptionValue("max_memory", Integer.toString(SAMWriting.MAX_RECORDS_IN_RAM)));
+		}
+
+		void log() {
+			logger.info("Using potential .bam file: " + filtered);
+			logger.info("Using output prefix: " + out);
+			logger.info("Mapping tool used for mobile mapping: " + tool);
+			logger.info("Paired-end reads: " + paired);
+			logger.info("Setting sample name to: " + sampleName);
+			logger.info("Using temp: " + TMP);
+		}
+	}
+
+	// =================================================================================================================
+
+	//TODO remove the duplicated code associated with this code
+	public static void runFromPropertiesFile(Properties prop) throws IOException {
+
 		long start = System.currentTimeMillis();
-		
-		single = new File(prop.getProperty(MobileDefinitions.INFILE_FROM_MOBIOME_MAPPING).trim());
-		//we are skipping the multiple input
-		
-		filtered = new File(prop.getProperty(MobileDefinitions.INFILE_FROM_POTENTIAL_MEI_FINDER).trim());
-		out = prop.getProperty(MobileDefinitions.OUTFILE).trim();
-		sampleName = prop.getProperty(MobileDefinitions.SAMPLE_NAME);
-		tool = prop.getProperty(MobileDefinitions.MOBIOME_MAPPING_TOOL);
-		paired = Boolean.parseBoolean(prop.getProperty(MobileDefinitions.PAIRED_END).trim());
-		MIN_POLYA_LEN = Integer.parseInt(prop.getProperty(MobileDefinitions.POLY_A_LENGTH).trim());
-		MAX_POLYA_MM = Integer.parseInt(prop.getProperty(MobileDefinitions.POLY_A_MAX_MISMATCHES).trim());
-		
-		if (prop.containsKey(MobileDefinitions.GRIPS_MAX_REFSEQ_MAPPING)){
-			MAX_MAPPINGS = Integer.parseInt(prop.getProperty(MobileDefinitions.GRIPS_MAX_REFSEQ_MAPPING));
-		}
-		
-		if (prop.containsKey(MobileDefinitions.TMP)){
-			TMP = prop.getProperty(MobileDefinitions.TMP).trim() + File.separator + "mob_" + Long.toString(System.nanoTime());			
-		}else{
-			TMP = System.getProperty("java.io.tmpdir") + File.separator + "mob_" + Long.toString(System.nanoTime());
-		}
-		
-		File tmp = new File(TMP);
-		
-		if ( ! tmp.mkdir() ){
-			throw new IOException("Can not create tmp directory: " + tmp);
-		}
-		MEMORY = Integer.parseInt(prop.getProperty(MobileDefinitions.MEMORY).trim());
-		
-		logger.info("Using potential .bam file: " + filtered);
-		logger.info("Using output prefix: " + out);
-		logger.info("Mapping tool used for mobile mapping: " + tool);
-		logger.info("Paired-end reads: " + paired);
-		logger.info("Setting sample name to: " + sampleName);
-		logger.info("Using temp: " + tmp);
-		
+
+		ValuesParsedFromPropertiesOrCmdLine valuesParsed = new ValuesParsedFromPropertiesOrCmdLine(prop);
+		valuesParsed.log();
+
 		try {
 			
 			if (Boolean.parseBoolean(prop.getProperty(MobileDefinitions.GRIPS_SKIP_UU_EXCLUSION))){
-				runRefAndMePairFinderSkipUUChecking(single, multiple, filtered, out, tool, paired, sampleName);
-			}else{
-				runRefAndMePairFinder(single, multiple, filtered, out, tool, paired, sampleName);
+				runRefAndMePairFinderSkipUUChecking(valuesParsed.single, valuesParsed.multiple, valuesParsed.filtered,
+						valuesParsed.out, valuesParsed.tool, valuesParsed.paired, valuesParsed.sampleName);
+			} else {
+				runRefAndMePairFinder(valuesParsed.single, valuesParsed.multiple, valuesParsed.filtered, valuesParsed.out,
+						valuesParsed.tool, valuesParsed.paired, valuesParsed.sampleName);
 			}
 			
 			//cleanup files if necessary:
 			
-			if(Boolean.parseBoolean(prop.getProperty(MobileDefinitions.CLEANUP_FILES))){
-				File datToDelete = new File(filtered.toString().replaceAll(".bam$", ".dat"));
-				File fqToDelete = new File(filtered.toString().replaceAll(".bam$", ".fq"));
-				File multipleBam = new File(single.toString().replaceAll(".bam$", ".multiple.bam"));
+			if (Boolean.parseBoolean(prop.getProperty(MobileDefinitions.CLEANUP_FILES))) {
+				File datToDelete = new File(valuesParsed.filtered.toString().replaceAll(".bam$", ".dat"));
+				File fqToDelete = new File(valuesParsed.filtered.toString().replaceAll(".bam$", ".fq"));
+				File multipleBam = new File(valuesParsed.single.toString().replaceAll(".bam$", ".multiple.bam"));
 				
-				logger.info("Will delete: " + filtered.toString());
+				logger.info("Will delete: " + valuesParsed.filtered.toString());
 				logger.info("Will delete: " + datToDelete.toString());
 				logger.info("Will delete: " + fqToDelete.toString());
-				logger.info("Will delete: " + single.toString());
+				logger.info("Will delete: " + valuesParsed.single.toString());
 				logger.info("Will delete: " + multipleBam.toString());
 				
-				logger.info(filtered.toString() + " deleted? : " + filtered.delete());				
+				logger.info(valuesParsed.filtered.toString() + " deleted? : " + valuesParsed.filtered.delete());
 				logger.info(datToDelete.toString() + " deleted? : " + datToDelete.delete());
 				logger.info(fqToDelete.toString() + " deleted? : " + fqToDelete.delete());
-				logger.info(single.toString() + " deleted? : " + single.delete());
+				logger.info(valuesParsed.single.toString() + " deleted? : " + valuesParsed.single.delete());
 				logger.info(multipleBam.toString() + " deleted? : " + multipleBam.delete());
-				
 			}
-			
 			
 			long end = System.currentTimeMillis();
 			long millis = end - start;
@@ -249,9 +308,9 @@ public class RefAndMEPairFinder {
 			logger.info("RefAndMEPairFinder ran in : " + time);
 		} catch (IOException e) {
 			logger.error("RefAndMEPairFinder -> Error in finding files: " + e.getMessage());
-		} finally{
-			if (tmp != null && ! tmp.delete() ){
-				logger.error("RefAndMEPairFinder -> Could not delete temp: " + tmp);
+		} finally {
+			if (valuesParsed.tmp != null && ! valuesParsed.tmp.delete() ){
+				logger.error("RefAndMEPairFinder -> Could not delete temp: " + valuesParsed.tmp.getAbsolutePath());
 			}
 		}
 	}
@@ -268,21 +327,20 @@ public class RefAndMEPairFinder {
 	 * @param paired: true if paired-end reads are used
 	 * @throws IOException
 	 */
-	public static void runRefAndMePairFinder(File singleBam, File multipleBam, File oriBam,
-			 String output, String tool, Boolean paired, String sampleName) throws IOException{
+	private static void runRefAndMePairFinder(File singleBam, File multipleBam, File oriBam,
+			 String output, String tool, Boolean paired, String sampleName) throws IOException {
 			
 		//TODO modify runRefAndMePairFinder to accept tool as a parameter, so different
 		//mapping tools can be used more easily with this class. Now it can still be done
 		//but multiple methods from this class need to be called seperately.
-		Vector<String> exclusionReads = new Vector<String>();
 		Map<String, MobileSAMTag> meReads;
 		
 		File nameSortedSingleBam = new File(singleBam.toString().replaceAll(".bam$","_nsorted.bam"));
 		
 		SAMWriting.writeSortedSAMorBAM(singleBam, nameSortedSingleBam, new File(TMP), MEMORY, SortOrder.queryname);
 		//SAMWriting.writeNameSortedSAMorBAM(singleBam, nameSortedSingleBam, new File(TMP), MEMORY);
-		
-		exclusionReads = getUUReadsMappingBothToME(nameSortedSingleBam);
+
+		Vector<String> exclusionReads = getUUReadsMappingBothToME(nameSortedSingleBam);
 		
 		meReads = getReadsMappingToME(nameSortedSingleBam, exclusionReads, tool);
 		
@@ -291,7 +349,6 @@ public class RefAndMEPairFinder {
 		}
 		
 		writeRefCoordinateFile(oriBam, meReads, output, paired, sampleName);
-		
 	}
 	
 	/**
@@ -306,8 +363,8 @@ public class RefAndMEPairFinder {
 	 * @param paired: true if paired-end reads are used
 	 * @throws IOException
 	 */
-	public static void runRefAndMePairFinderSkipUUChecking(File singleBam, File multipleBam, File oriBam,
-			 String output, String tool, Boolean paired, String sampleName) throws IOException{
+	private static void runRefAndMePairFinderSkipUUChecking(File singleBam, File multipleBam, File oriBam,
+			 String output, String tool, Boolean paired, String sampleName) throws IOException {
 			
 		//TODO modify runRefAndMePairFinder to accept tool as a parameter, so different
 		//mapping tools can be used more easily with this class. Now it can still be done
@@ -326,7 +383,6 @@ public class RefAndMEPairFinder {
 		}
 		
 		writeRefCoordinateFile(oriBam, meReads, output, paired, sampleName);
-		
 	}
 
 	/**
@@ -338,7 +394,7 @@ public class RefAndMEPairFinder {
 	 * @param bam name sorted bam file with mappings against mobile reference
 	 * @return Vector of readnames of UU pairs with both mapping to mobile element
 	 */
-	public static Vector<String> getUUReadsMappingBothToME(File bam){
+	private static Vector<String> getUUReadsMappingBothToME(File bam) {
 		SAMFileReader inputSam = new SAMSilentReader(bam);
 		String readName = "";
 		String previousReadName = "dummy";
@@ -347,7 +403,7 @@ public class RefAndMEPairFinder {
 		
 		int c = 0;
 		
-		 for (SAMRecord samRecord : inputSam){
+		 for (SAMRecord samRecord : inputSam) {
 			 readName = samRecord.getReadName();
 			 
 			 //readName.length() - 1 to get rid of the last character in the read name, which with paired-end reads
@@ -387,7 +443,7 @@ public class RefAndMEPairFinder {
 	 * not occuring in exclusion vector.
 	 */
 	public static Map<String, MobileSAMTag> getReadsMappingToME(File bam,
-			Vector<String> exclusion, String tool){
+			Vector<String> exclusion, String tool) {
 		
 		Map<String, MobileSAMTag> meReads = new HashMap<String, MobileSAMTag>();
 		SAMFileReader inputSam = new SAMSilentReader(bam);	
@@ -396,12 +452,12 @@ public class RefAndMEPairFinder {
 		
 		logger.info("Using max mobiome mappings of (-1 is disabled) : " + MAX_MAPPINGS);
 		
-		for (SAMRecord samRecord : inputSam){
+		for (SAMRecord samRecord : inputSam) {
 			
 			String recordName = samRecord.getReadName();
 			boolean splitRead = recordName.startsWith(SAMDefinitions.SPLIT_MAPPING);
 			
-			if(MAX_MAPPINGS != -1){
+			if (MAX_MAPPINGS != -1) {
 				MobileSAMTag tempTag = new MobileSAMTag();
 				try {
 					tempTag.build(samRecord, tool);
@@ -417,7 +473,7 @@ public class RefAndMEPairFinder {
 				
 			}
 			
-			if (!samRecord.getReadUnmappedFlag() && !exclusion.contains(samRecord.getReadName())){
+			if (!samRecord.getReadUnmappedFlag() && !exclusion.contains(samRecord.getReadName())) {
 				mobileReadCounter++;
 				
 				MobileSAMTag mobileTag = new MobileSAMTag();
@@ -428,12 +484,12 @@ public class RefAndMEPairFinder {
 							seq.reverseComplement();
 						}
 						String homoPolymer = "";
-						if (recordName.charAt(1) == SAMDefinitions.LEFT_CLIPPED){
+						if (recordName.charAt(1) == SAMDefinitions.LEFT_CLIPPED) {
 							homoPolymer = seq.getPolyAOrTMapping(MIN_POLYA_LEN, MAX_POLYA_MM, false);
-						}else if(recordName.charAt(1) == SAMDefinitions.RIGHT_CLIPPED){
+						} else if(recordName.charAt(1) == SAMDefinitions.RIGHT_CLIPPED) {
 							homoPolymer = seq.getPolyAOrTMapping(MIN_POLYA_LEN, MAX_POLYA_MM, true);
 						}
-						if("polyA".equalsIgnoreCase(homoPolymer) || "polyT".equalsIgnoreCase(homoPolymer)){
+						if ("polyA".equalsIgnoreCase(homoPolymer) || "polyT".equalsIgnoreCase(homoPolymer)) {
 							mobileTag.setHomoPolymer(homoPolymer);
 						}
 					}
@@ -443,10 +499,10 @@ public class RefAndMEPairFinder {
 					logger.error(e.getMessage());
 				} catch (UnknownParamException e) {
 					logger.error(e.getMessage());
-				} catch (InvalidNucleotideSequenceException e){
+				} catch (InvalidNucleotideSequenceException e) {
 					logger.error(e.getMessage());
 				}
-			}else if(splitRead && samRecord.getReadUnmappedFlag()){
+			} else if(splitRead && samRecord.getReadUnmappedFlag()) {
 				NucleotideSequence splitSeq;
 				try {
 					String homoPolymer = "";
@@ -465,9 +521,9 @@ public class RefAndMEPairFinder {
 					
 				} catch (InvalidNucleotideSequenceException e) {
 					logger.error(e.getMessage());
-				} catch (InvalidCategoryException e){
+				} catch (InvalidCategoryException e) {
 					logger.error(e.getMessage());
-				}catch (UnknownParamException e) {
+				} catch (UnknownParamException e) {
 					logger.error(e.getMessage());
 				}
 			}
@@ -488,20 +544,20 @@ public class RefAndMEPairFinder {
 	 * containing mobile read mapping info
 	 * @param exclusion vector of reads not to include in this analysis.
 	 */
-	public static void updateReadsMappingToMultipleME(File bam, Map<String, MobileSAMTag> meReads,
-			Vector<String> exclusion){
+	private static void updateReadsMappingToMultipleME(File bam, Map<String, MobileSAMTag> meReads,
+			Vector<String> exclusion) {
 		
 		SAMFileReader inputSam = new SAMSilentReader(bam);
 		
 		String readName;
 		int c = 0;
 				
-		for (SAMRecord samRecord : inputSam){
+		for (SAMRecord samRecord : inputSam) {
 			readName = samRecord.getReadName();
-			if(!exclusion.contains(readName) && meReads.containsKey(readName)){
+			if (!exclusion.contains(readName) && meReads.containsKey(readName)) {
 				try {
 					if (meReads.get(readName).getHomoPolymer().equals("") &&
-							meReads.get(readName).addMobileCategoryByReference(samRecord.getReferenceName())){
+							meReads.get(readName).addMobileCategoryByReference(samRecord.getReferenceName())) {
 						logger.info(readName);
 						c++;
 					}
@@ -527,7 +583,7 @@ public class RefAndMEPairFinder {
 	 * @throws IOException
 	 */
 	public static void writeRefCoordinateFile(File originalBam,
-			Map<String, MobileSAMTag> meReads, String out, Boolean paired, String sampleName) throws IOException{
+			Map<String, MobileSAMTag> meReads, String out, Boolean paired, String sampleName) {
 		
 		String mobileSAMValue = "";
 		StringBuilder anchor = new StringBuilder();
@@ -543,27 +599,27 @@ public class RefAndMEPairFinder {
 		
 		int c = 0;
 		int d = 0;
-		for (SAMRecord samRecord : inputSam){
+		for (SAMRecord samRecord : inputSam) {
 			anchor.append(samRecord.getReadName());
 			splitRead = false;
-			if(paired){
+			if (paired) {
 				anchor.append(SAMDefinitions.READ_NUMBER_SEPERATOR);
 				splitRead = anchor.toString().startsWith(SAMDefinitions.SPLIT_MAPPING);
-				if(samRecord.getFirstOfPairFlag()){
+				if (samRecord.getFirstOfPairFlag()) {
 					if(splitRead){
 						anchor.append("1");
-					}else{
+					} else {
 						anchor.append("2");
 					}
-				}else{
+				} else {
 					if(splitRead){
 						anchor.append("2");
-					}else{
+					} else {
 						anchor.append("1");
 					}
 				}
 			}
-			if(meReads.containsKey(anchor.toString())){
+			if (meReads.containsKey(anchor.toString())) {
 				//in this case samRecord is anchor point for mobile Mate
 				mobileSAMValue = meReads.get(anchor.toString()).toString();
 
@@ -571,10 +627,10 @@ public class RefAndMEPairFinder {
 				samRecord.setAttribute(MobileDefinitions.SAM_TAG_SAMPLENAME, sampleName);
 
 				
-				if(splitRead){
+				if (splitRead) {
 					splitClusterSam.addAlignment(samRecord);
 					c++;
-				}else{
+				} else {
 					mateClusterSam.addAlignment(samRecord);
 					d++;
 				}
@@ -588,78 +644,4 @@ public class RefAndMEPairFinder {
 		mateClusterSam.close();
 		splitClusterSam.close();
 	}
-
-	public static Options createCmdOptions(){
-		Options options = new Options();
-		
-		OptionBuilder.withArgName("BAM File");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("BAM file (NAME-sorted!) from mobile ref mapping," +
-				"containing at most 1 mapping per read");
-		
-		options.addOption(OptionBuilder.create("single"));
-		
-		OptionBuilder.withArgName("BAM File");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("BAM file (NAME-sorted!) from mobile ref mapping,"
-				+ "containing all mappings of multiply mapped reads");
-		
-		options.addOption(OptionBuilder.create("multiple"));
-		
-		OptionBuilder.withArgName("BAM File");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("BAM file containing pairs potentially supporting MEI events" +
-				" (output BAM file of PotentialMEIFinder");
-		
-		options.addOption(OptionBuilder.create("potential"));
-		
-		OptionBuilder.withArgName("prefix");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Output prefix for BAM file containing anchors");
-		
-		options.addOption(OptionBuilder.create("out"));
-		
-		OptionBuilder.withArgName("Mapping tool");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Mapping tool used for mobile mapping, default: " + 
-				SAMDefinitions.MAPPING_TOOL_MOSAIK);
-		
-		options.addOption(OptionBuilder.create("tool"));
-		
-		OptionBuilder.withArgName("Paired-End Data");
-		OptionBuilder.withDescription("Whether the original mapping is done using paired-end reads." +
-				" Leave -p out when using single-end fragment data.");
-		
-		options.addOption(OptionBuilder.create("p"));
-		
-		OptionBuilder.withArgName("SampleName");
-		OptionBuilder.withDescription("name of sample");
-		options.addOption(OptionBuilder.create("samplename"));
-		
-		OptionBuilder.withArgName("dir");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Tmp directory to use, when writing large files");
-		
-		options.addOption(OptionBuilder.create("tmp"));
-		
-		OptionBuilder.withArgName("int");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Alter the number of records in memory (increase to decrease number of file handles). Default: " + SAMWriting.MAX_RECORDS_IN_RAM);
-		
-		options.addOption(OptionBuilder.create("max_memory"));
-		
-		OptionBuilder.withArgName("string");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Use property file instead of command line arguments, command line arguments will be skipt. Values in property file will be used");
-		
-		options.addOption(OptionBuilder.create("properties"));
-		
-		OptionBuilder.withArgName("int");
-		OptionBuilder.hasArg();
-		OptionBuilder.withDescription("Maximum number of mappings a read may map to the mobiome");
-		options.addOption(OptionBuilder.create("max_mapping"));
-		
-		return options;
-	}
-	
 }


### PR DESCRIPTION
  The two modules are:

 * `PotentialMEIReadFinder`
 * `RefAndMEPairFinder`

The refactoring is basically trying to have a single method for parsing options, for each class/tool respectively.

I believe this refactoring helps clarify the code a bit, and makes productionizing the tool a bit easier.