### PR TITLE
Remove space in annotation `no tsd`

### DIFF
--- a/src/main/java/org/umcn/me/pairedend/MobilePrediction.java
+++ b/src/main/java/org/umcn/me/pairedend/MobilePrediction.java
@@ -755,7 +755,7 @@ public class MobilePrediction  {
 			}else if(this.right_aligned_split_border > this.left_aligned_split_border){
 				return "deletion";
 			}else{
-				return "no tsd";
+				return "no_tsd";
 			}
 			
 		}else if (this.hasLeftAlignedSplitCluster() && this.hasRightMateCluster()){


### PR DESCRIPTION
Change space in 
`no tsd` to `no_tsd`.
Reason: 
later conversion to VCF currently don't fix this; and space is an illegal character in VCF body